### PR TITLE
Copy Edits on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ With tcomb-form you simply call `var Form = t.form.createForm(domainModel)` to g
 
 # Contributions
 
-A special thank to [William Lubelski](https://github.com/lubelski) ([@uiwill](https://twitter.com/uiwill)), without him this library would be less magic.
+Special thanks to [William Lubelski](https://github.com/lubelski) ([@uiwill](https://twitter.com/uiwill)), without him this library would be less magic.
 
-Thanks to [Esa-Matti Suuronen](https://github.com/epeli) for the `humanize()` function (regexps are not my forte).
+Thanks to [Esa-Matti Suuronen](https://github.com/epeli) for the excellent `humanize()` function.
 
 # Example
 


### PR DESCRIPTION
I decided to cut out the middle step.  
- Updated the playground copy to make the link more obvious
- I threw in my twitter handle
- 'suck' is not the most professional of terminology, even if writing regexps does suck
- This diff has looks bigger than it really is because I apparently have a text-editor plugin that automatically strips trailing whitespace and one that appends newlines at the end of files.  (I recommend both, but I can disable if you don't want to use those conventions and it becomes a pain)
