### PR TITLE
Sort choices only if order option is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function getChoices(map, order, emptyChoice) {
   });
   if (order) {
     // apply an order (asc, desc) to options
-    choices.sort(Order.meta.map[order || 'asc']);
+    choices.sort(Order.meta.map[order]);
   }
   if (emptyChoice) {
     // add an empty choice as the first choice

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -129,7 +129,7 @@ function getChoices(map, order, emptyChoice) {
   });
   if (order) {
     // apply an order (asc, desc) to options
-    choices.sort(Order.meta.map[order || 'asc']);
+    choices.sort(Order.meta.map[order]);
   }
   if (emptyChoice) {
     // add an empty choice as the first choice


### PR DESCRIPTION
I noticed that choices are always sorted, also if no `order` option is set. I propose to sort only if the order option is set and keep the current order otherwise.
I also noticed that JavaScript isn't good at sorting unicode strings. In my german country select, i have countries starting with special characters (like Österreich) sorted at the bottom of the select.
