### PR TITLE
Always add control-label class to labels

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,8 +157,8 @@ function getOptionalLabel(name, optional) {
 
 function getLabel(label, breakpoints) {
   var classes = {};
+  classes['control-label'] = true;
   if (breakpoints) {
-    classes['control-label'] = true;
     classes[breakpoints.toLabelClassName()] = true;
   }
   return label ? React.createElement("label", {className: cx(classes)}, label) : null;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -151,8 +151,8 @@ function getOptionalLabel(name, optional) {
 
 function getLabel(label, breakpoints) {
   var classes = {};
+  classes['control-label'] = true;
   if (breakpoints) {
-    classes['control-label'] = true;
     classes[breakpoints.toLabelClassName()] = true;
   }
   return label ? <label className={cx(classes)}>{label}</label> : null;


### PR DESCRIPTION
Required for example for displaying [validation states](http://getbootstrap.com/css/#forms-control-validation) correctly.
