### PR TITLE
Set displayName for Form class

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -12,6 +12,8 @@ function create(type, opts) {
 
   var Form = React.createClass({
 
+    displayName: 'Form',
+
     // the public api returns `null` if validation failed
     // unless the optional boolean argument `raw` is set to `true`
     getValue: function (raw) {


### PR DESCRIPTION
I was inspecting the generated tree with React Developer Tools and I noticed the Form element has no `displayName` set. (If it was intentional and not just an oversight, ignore the PR :-) ).
