### PR TITLE
[WIP] Typescript definition improvements

### DIFF
--- a/definitions/tcomb-form.d.ts
+++ b/definitions/tcomb-form.d.ts
@@ -182,7 +182,7 @@ declare module tcomb {
       onChange?: (value: any) => void;
     }
 
-    interface Form extends React.ComponentClass<FormProps> {}
+    interface Form extends React.ReactElement<any> {}
 
     //
     // exports


### PR DESCRIPTION
I started using your fresh definition file, I will use this to let you know about the changes I needed to make to use it in our project. 

- Form must be a `React.Element` to work with react-router. If it's a `React.ComponentClass` it can not be used inside a route handle.