### PR TITLE
Adding elements to a List, use `undefined` as new value

### DIFF
--- a/lib/components/List.js
+++ b/lib/components/List.js
@@ -86,7 +86,7 @@ var List = React.createClass({
 
   addItem: function (evt) {
     evt.preventDefault();
-    var value = this.state.value.concat(null);
+    var value = this.state.value.concat(undefined);
     var keys = this.state.keys.concat(uuid());
     this.onChange(value, keys, this.props.ctx.path.concat(value.length - 1));
   },


### PR DESCRIPTION
Right now `null` is used. This causes React not to use the `value`
property returned by `getDefaultProps`, forcing the listed component to
manually specify its default `value` prop in `setInitialState` and
`componentWillReceiveProps` (as in http://git.io/ve0tH).

Again, I don't know the codebase very well, so this seemingly innocuous change could break everything :smile: , feel free to discard it (I wanted to be a bit more proactive and not open another issue :-) ).

I've re-run tests, but didn't commit the changes to `test/tests.js`, as I suspect they also included some patch dependency updates. I'm not familiar with `tape`, so I couldn't really tell whether they all passed or not, is there a report where one can check?