### PR TITLE
Add travis-ci setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+sudo: false
+node_js:
+- iojs
+- "0.12"


### PR DESCRIPTION
Hi, would you add Travis-CI setting?

I have a question. I exec `npm test`, but this command does not show the test result. How to test `tcomb-form`?
```
$ npm test

> tcomb-form@0.5.0 test /Users/sane/work/js-study/tcomb-form
> echo "Compiling tests. Once finished open ./test/index.html in your browser..." && watchify -t [babelify --stage 0 --loose] test/index.js -o test/browser.js  -v -x react

Compiling tests. Once finished open ./test/index.html in your browser...
296858 bytes written to test/browser.js (5.32 seconds)
```