### PR TITLE
Add setState callback to onChange method.

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -144,9 +144,12 @@ export class Component extends React.Component {
     this.setState({value: this.getTransformer().format(props.value)});
   }
 
-  onChange(value) {
+  onChange(value, callback) {
     this.setState({value}, () => {
       this.props.onChange(value, this.props.ctx.path);
+      if (callback && typeof callback === 'function') {
+        callback(value, this.props.ctx.path);
+      }
     });
   }
 


### PR DESCRIPTION
When I write my custom components, and use `locals.onChange` I need to know when the state has changed.
This callback solves this problem.