### PR TITLE
v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@
 
 **Note**: Gaps between patch versions are faulty/broken releases.
 
+## v0.7.1
+
+- **Internal**
+    - upgrade to latest version of tcomb-validation (2.2.0)
+    - removed react-dom dependency
+    - removed debug dependency
+- **New Feature**
+    - added argument `context` to `error` options that are functions (new signature: `error(value, path, context)`)
+    - added `error` option default if the type constructor owns a `getValidationErrorMessage(value, path, context)` function
+    - added `context` prop to all components (passed into `error` as `context` argument)
+
 ## v0.7.0
 
 - **Breaking Change**

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -10,6 +10,7 @@ $ npm install tcomb-form
 
 ```js
 var React = require('react');
+var ReactDOM = require('react/lib/ReactDOM');
 var t = require('tcomb-form');
 var Form = t.form.Form;
 
@@ -46,7 +47,7 @@ var App = React.createClass({
 
 });
 
-React.render(<App />, document.getElementById('app'));
+ReactDOM.render(<App />, document.getElementById('app'));
 ```
 
 > **Note**. Labels are automatically generated.
@@ -181,6 +182,46 @@ var App = React.createClass({
           type={Person}
         />
         <button type="submit">Save</button>
+      </form>
+    );
+  }
+
+});
+```
+
+### Customised error messages
+
+```js
+var Name = t.subtype(t.String, function (s) { return s.length > 2; });
+
+// if you define a getValidationErrorMessage function it will be called on validation errors
+Name.getValidationErrorMessage = function (value, path, context) {
+  return 'error message with locale: ' + context.locale;
+};
+
+var Schema = t.struct({
+  name: Name
+});
+
+var App = React.createClass({
+
+  onSubmit(evt) {
+    evt.preventDefault();
+    var value = this.refs.form.getValue();
+    if (value) {
+      console.log(value);
+    }
+  },
+
+  render() {
+    return (
+      <form onSubmit={this.onSubmit}>
+        <t.form.Form
+          ref="form"
+          type={Schema}
+          context={{locale: 'it-IT'}}
+        />
+        <button type="submit" className="btn btn-primary">Save</button>
       </form>
     );
   }
@@ -353,7 +394,7 @@ var Persons = t.list(Person);
 
 # Rendering options
 
-In order to customize the look and feel, use an `options` prop:
+In order to customise the look and feel, use an `options` prop:
 
 ```js
 <Form type={Model} options={options} />
@@ -490,10 +531,12 @@ var options = {
 `error` can also be a function with the following signature:
 
 ```
-(value: any) => ?(string | ReactElement)
+(value, path, context) => ?(string | ReactElement)
 ```
 
-where `value` is an object containing the current form value.
+- `value` is an object containing the current form value.
+- `path` is the path of the value being validated
+- `context` is the value of the `context` prop
 
 If you want to show the error message onload, add the `hasError` option:
 
@@ -536,7 +579,7 @@ var options = {
 
 ### Look and feel
 
-You can customize the look and feel with the `template` option:
+You can customise the look and feel with the `template` option:
 
 ```js
 var options = {
@@ -706,7 +749,7 @@ The following options are similar to the textbox ones:
 
 ### Null option
 
-You can customize the null option with the `nullOption` option:
+You can customise the null option with the `nullOption` option:
 
 ```js
 var options = {
@@ -740,7 +783,7 @@ var options = {
 
 ### Custom options
 
-You can customize the options with the `options` option:
+You can customise the options with the `options` option:
 
 ```js
 var options = {
@@ -839,7 +882,7 @@ The following options are similar to the textbox ones:
 
 ## Templates
 
-To customize the "skin" of tcomb-form you have to write a *template*. A template is simply a function with the following signature:
+To customise the "skin" of tcomb-form you have to write a *template*. A template is simply a function with the following signature:
 
 ```
 (locals: any) => UVDOM | ReactElement
@@ -906,7 +949,7 @@ var petLayout = function(locals){
 var options = {
   template: formLayout,
   fields: {
-    pets: { // <- pets is a list, you can customize the elements with the `item` option
+    pets: { // <- pets is a list, you can customise the elements with the `item` option
       item: {
         template: petLayout
       }
@@ -948,8 +991,6 @@ var App = React.createClass({
   }
 
 });
-
-React.render(<App />, document.getElementById('app'));
 ```
 
 ## Transformers

--- a/lib/components.js
+++ b/lib/components.js
@@ -24,10 +24,6 @@ var _uvdomReact = require('uvdom/react');
 
 var _util = require('./util');
 
-var _debug = require('debug');
-
-var _debug2 = _interopRequireDefault(_debug);
-
 var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
@@ -35,7 +31,6 @@ var _classnames2 = _interopRequireDefault(_classnames);
 var Nil = _tcombValidation2['default'].Nil;
 var assert = _tcombValidation2['default'].assert;
 var SOURCE = 'tcomb-form';
-var log = _debug2['default'](SOURCE);
 var noobj = Object.freeze({});
 var noarr = Object.freeze([]);
 var noop = function noop() {};
@@ -166,7 +161,6 @@ var Component = (function (_React$Component) {
 
   Component.prototype.shouldComponentUpdate = function shouldComponentUpdate(nextProps, nextState) {
     var should = nextState.value !== this.state.value || nextState.hasError !== this.state.hasError || nextProps.options !== this.props.options || nextProps.type !== this.props.type;
-    //log('shouldComponentUpdate', this.constructor.name, should);
     return should;
   };
 
@@ -185,9 +179,16 @@ var Component = (function (_React$Component) {
     });
   };
 
+  Component.prototype.getContext = function getContext() {
+    return {
+      path: this.props.ctx.path,
+      context: this.props.context || this.props.ctx.context
+    };
+  };
+
   Component.prototype.validate = function validate() {
     var value = this.getTransformer().parse(this.state.value);
-    var result = _tcombValidation2['default'].validate(value, this.props.type, this.props.ctx.path);
+    var result = _tcombValidation2['default'].validate(value, this.props.type, this.getContext());
     this.setState({ hasError: !result.isValid() });
     return result;
   };
@@ -219,8 +220,12 @@ var Component = (function (_React$Component) {
   };
 
   Component.prototype.getError = function getError() {
-    var error = this.props.options.error;
-    return _tcombValidation2['default'].Func.is(error) ? error(this.state.value) : error;
+    var error = this.props.options.error || this.props.type.getValidationErrorMessage;
+    if (_tcombValidation2['default'].Func.is(error)) {
+      var validationContext = this.getContext();
+      return error(this.state.value, validationContext.path, validationContext.context);
+    }
+    return error;
   };
 
   Component.prototype.hasError = function hasError() {
@@ -263,7 +268,6 @@ var Component = (function (_React$Component) {
   };
 
   Component.prototype.render = function render() {
-    //log('rendering %s', this.constructor.name);
     var locals = this.getLocals();
     // getTemplate is the only required implementation when extending Component
     assert(_tcombValidation2['default'].Func.is(this.getTemplate), '[' + SOURCE + '] missing getTemplate method of component ' + this.constructor.name);
@@ -564,7 +568,7 @@ var Struct = (function (_Component6) {
       var InnerType = this.typeInfo.innerType;
       value = new InnerType(value);
       if (this.typeInfo.isSubtype && errors.length === 0) {
-        result = _tcombValidation2['default'].validate(value, this.props.type, this.props.ctx.path);
+        result = _tcombValidation2['default'].validate(value, this.props.type, this.getContext());
         hasError = !result.isValid();
         errors = errors.concat(result.errors);
       }
@@ -618,6 +622,7 @@ var Struct = (function (_Component6) {
           value: value[prop],
           onChange: this.onChange.bind(this, prop),
           ctx: {
+            context: ctx.context,
             uidGenerator: ctx.uidGenerator,
             auto: auto,
             config: config,
@@ -722,7 +727,7 @@ var List = (function (_Component7) {
 
     // handle subtype
     if (this.typeInfo.isSubtype && errors.length === 0) {
-      result = _tcombValidation2['default'].validate(value, this.props.type, this.props.ctx.path);
+      result = _tcombValidation2['default'].validate(value, this.props.type, this.getContext());
       hasError = !result.isValid();
       errors = errors.concat(result.errors);
     }
@@ -820,6 +825,7 @@ var List = (function (_Component7) {
           value: value,
           onChange: _this3.onItemChange.bind(_this3, i),
           ctx: {
+            context: ctx.context,
             uidGenerator: ctx.uidGenerator,
             auto: auto,
             config: config,
@@ -902,6 +908,7 @@ var Form = (function (_React$Component2) {
       value: this.props.value,
       onChange: this.props.onChange || noop,
       ctx: this.props.ctx || {
+        context: this.props.context,
         uidGenerator: this.uidGenerator,
         auto: 'labels',
         templates: templates,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-form",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React.js powered UI library for developing forms writing less code",
   "main": "index.js",
   "scripts": {
@@ -21,10 +21,8 @@
   "homepage": "https://github.com/gcanti/tcomb-form",
   "dependencies": {
     "react": "^0.14.0-rc1",
-    "react-dom": "^0.14.0-rc1",
-    "tcomb-validation": "^2.1.1",
+    "tcomb-validation": "^2.2.0",
     "classnames": "^2.1.3",
-    "debug": "^2.1.1",
     "uvdom": "^0.2.0",
     "uvdom-bootstrap": "^0.2.3"
   },

--- a/test/components/util.js
+++ b/test/components/util.js
@@ -2,6 +2,7 @@
 
 var t = require('tcomb-validation');
 var React = require('react');
+var ReactDOM = require('react/lib/ReactDOM');
 var bootstrap = require('../../lib/templates/bootstrap');
 var UIDGenerator = require('../../lib/util').UIDGenerator;
 
@@ -36,7 +37,7 @@ function getRenderComponent(Component) {
     props.ctx = props.ctx || ctx;
     var node = document.createElement('div');
     document.body.appendChild(node);
-    return React.render(React.createElement(Component, props), node);
+    return ReactDOM.render(React.createElement(Component, props), node);
   };
 }
 


### PR DESCRIPTION
- **Internal**
    - upgrade to latest version of tcomb-validation (2.2.0)
    - removed react-dom dependency
    - removed debug dependency
- **New Feature**
    - added argument `context` to `error` options that are functions
(new signature: `error(value, path, context)`)
    - added `error` option default if the type constructor owns a
`getValidationErrorMessage(value, path, context)` function
    - added `context` prop to all components (passed into `error` as
`context` argument)