### PR TITLE
Add className to locals of Struct and List

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -643,6 +643,7 @@ var Struct = (function (_Component6) {
     var locals = _Component6.prototype.getLocals.call(this);
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
+    locals.className = options.className;
     return locals;
   };
 
@@ -850,6 +851,7 @@ var List = (function (_Component7) {
       click: this.addItem.bind(this)
     };
     locals.items = this.getItems();
+    locals.className = options.className;
     return locals;
   };
 

--- a/src/components.js
+++ b/src/components.js
@@ -519,6 +519,7 @@ export class Struct extends Component {
     const locals = super.getLocals();
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
+    locals.className = options.className;
     return locals;
   }
 
@@ -693,6 +694,7 @@ export class List extends Component {
       click: this.addItem.bind(this)
     };
     locals.items = this.getItems();
+    locals.className = options.className;
     return locals;
   }
 


### PR DESCRIPTION
`locals.className` is used in the bootstrap template's [struct()](https://github.com/gcanti/tcomb-form/blob/v0.6.5/src/templates/bootstrap.js#L602-L605) and [list()](https://github.com/gcanti/tcomb-form/blob/v0.6.5/src/templates/bootstrap.js#L602-L605) but is never passed.

Note, that i opened against the 0.6.x branch because i'm using this version. This might be ported to the other branches too.