### PR TITLE
Generic Factory

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -134,7 +134,7 @@ var Component = (function (_React$Component) {
   }]);
 
   function Component(props) {
-    _classCallCheck(this, Component);
+    _classCallCheck(this, _Component);
 
     _React$Component.call(this, props);
     this.typeInfo = _util.getTypeInfo(props.type);
@@ -257,6 +257,7 @@ var Component = (function (_React$Component) {
   Component.prototype.getLocals = function getLocals() {
     var options = this.props.options;
     var value = this.state.value;
+    var attrs = this.getAttrs();
     return {
       typeInfo: this.typeInfo,
       path: this.props.ctx.path,
@@ -265,7 +266,7 @@ var Component = (function (_React$Component) {
       label: this.getLabel(),
       onChange: this.onChange.bind(this),
       config: this.getConfig(),
-      value: value,
+      value: value, attrs: attrs,
       disabled: options.disabled,
       help: options.help
     };
@@ -279,6 +280,8 @@ var Component = (function (_React$Component) {
     return _uvdomReact.compile(template(locals));
   };
 
+  var _Component = Component;
+  Component = decorators.attrs(Component) || Component;
   return Component;
 })(_react2['default'].Component);
 
@@ -294,13 +297,13 @@ function parseNumber(value) {
   return isNumeric ? n : toNull(value);
 }
 
-var Textbox = (function (_Component) {
-  _inherits(Textbox, _Component);
+var Textbox = (function (_Component2) {
+  _inherits(Textbox, _Component2);
 
   function Textbox() {
     _classCallCheck(this, _Textbox);
 
-    _Component.apply(this, arguments);
+    _Component2.apply(this, arguments);
   }
 
   Textbox.prototype.getTransformer = function getTransformer() {
@@ -318,7 +321,7 @@ var Textbox = (function (_Component) {
   };
 
   Textbox.prototype.getLocals = function getLocals() {
-    var locals = _Component.prototype.getLocals.call(this);
+    var locals = _Component2.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.attrs.placeholder = this.getPlaceholder();
     locals.type = this.props.options.type || 'text';
@@ -353,17 +356,17 @@ var Textbox = (function (_Component) {
 
 exports.Textbox = Textbox;
 
-var Checkbox = (function (_Component2) {
-  _inherits(Checkbox, _Component2);
+var Checkbox = (function (_Component3) {
+  _inherits(Checkbox, _Component3);
 
   function Checkbox() {
     _classCallCheck(this, _Checkbox);
 
-    _Component2.apply(this, arguments);
+    _Component3.apply(this, arguments);
   }
 
   Checkbox.prototype.getLocals = function getLocals() {
-    var locals = _Component2.prototype.getLocals.call(this);
+    var locals = _Component3.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     // checkboxes must always have a label
     locals.label = locals.label || this.getDefaultLabel();
@@ -391,13 +394,13 @@ var Checkbox = (function (_Component2) {
 
 exports.Checkbox = Checkbox;
 
-var Select = (function (_Component3) {
-  _inherits(Select, _Component3);
+var Select = (function (_Component4) {
+  _inherits(Select, _Component4);
 
   function Select() {
     _classCallCheck(this, _Select);
 
-    _Component3.apply(this, arguments);
+    _Component4.apply(this, arguments);
   }
 
   Select.prototype.getTransformer = function getTransformer() {
@@ -437,7 +440,7 @@ var Select = (function (_Component3) {
   };
 
   Select.prototype.getLocals = function getLocals() {
-    var locals = _Component3.prototype.getLocals.call(this);
+    var locals = _Component4.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     locals.isMultiple = this.isMultiple();
@@ -478,13 +481,13 @@ var Select = (function (_Component3) {
 
 exports.Select = Select;
 
-var Radio = (function (_Component4) {
-  _inherits(Radio, _Component4);
+var Radio = (function (_Component5) {
+  _inherits(Radio, _Component5);
 
   function Radio() {
     _classCallCheck(this, _Radio);
 
-    _Component4.apply(this, arguments);
+    _Component5.apply(this, arguments);
   }
 
   Radio.prototype.getOptions = function getOptions() {
@@ -497,7 +500,7 @@ var Radio = (function (_Component4) {
   };
 
   Radio.prototype.getLocals = function getLocals() {
-    var locals = _Component4.prototype.getLocals.call(this);
+    var locals = _Component5.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     return locals;
@@ -524,13 +527,13 @@ var Radio = (function (_Component4) {
 
 exports.Radio = Radio;
 
-var Datetime = (function (_Component5) {
-  _inherits(Datetime, _Component5);
+var Datetime = (function (_Component6) {
+  _inherits(Datetime, _Component6);
 
   function Datetime() {
     _classCallCheck(this, _Datetime);
 
-    _Component5.apply(this, arguments);
+    _Component6.apply(this, arguments);
   }
 
   Datetime.prototype.getOrder = function getOrder() {
@@ -538,7 +541,7 @@ var Datetime = (function (_Component5) {
   };
 
   Datetime.prototype.getLocals = function getLocals() {
-    var locals = _Component5.prototype.getLocals.call(this);
+    var locals = _Component6.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.order = this.getOrder();
     return locals;
@@ -566,13 +569,13 @@ var Datetime = (function (_Component5) {
 
 exports.Datetime = Datetime;
 
-var Struct = (function (_Component6) {
-  _inherits(Struct, _Component6);
+var Struct = (function (_Component7) {
+  _inherits(Struct, _Component7);
 
   function Struct() {
     _classCallCheck(this, _Struct);
 
-    _Component6.apply(this, arguments);
+    _Component7.apply(this, arguments);
   }
 
   Struct.prototype.isValueNully = function isValueNully() {
@@ -690,7 +693,7 @@ var Struct = (function (_Component6) {
 
   Struct.prototype.getLocals = function getLocals() {
     var options = this.props.options;
-    var locals = _Component6.prototype.getLocals.call(this);
+    var locals = _Component7.prototype.getLocals.call(this);
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
     locals.className = options.className;
@@ -728,8 +731,8 @@ function toSameLength(value, keys, uidGenerator) {
   return ret;
 }
 
-var List = (function (_Component7) {
-  _inherits(List, _Component7);
+var List = (function (_Component8) {
+  _inherits(List, _Component8);
 
   _createClass(List, null, [{
     key: 'transformer',
@@ -747,7 +750,7 @@ var List = (function (_Component7) {
   function List(props) {
     _classCallCheck(this, _List);
 
-    _Component7.call(this, props);
+    _Component8.call(this, props);
     this.state.keys = this.state.value.map(function () {
       return props.ctx.uidGenerator.next();
     });
@@ -906,7 +909,7 @@ var List = (function (_Component7) {
   List.prototype.getLocals = function getLocals() {
     var options = this.props.options;
     var i18n = this.getI18n();
-    var locals = _Component7.prototype.getLocals.call(this);
+    var locals = _Component8.prototype.getLocals.call(this);
     locals.add = options.disableAdd ? null : {
       label: i18n.add,
       click: this.addItem.bind(this)

--- a/lib/components.js
+++ b/lib/components.js
@@ -41,7 +41,6 @@ function getComponent(_x, _x2) {
   _function: while (_again) {
     var type = _x,
         options = _x2;
-    name = undefined;
     _again = false;
 
     if (options.factory) {
@@ -62,6 +61,7 @@ function getComponent(_x, _x2) {
         _x = type.meta.type;
         _x2 = options;
         _again = true;
+        name = undefined;
         continue _function;
 
       default:
@@ -294,13 +294,65 @@ function parseNumber(value) {
   return isNumeric ? n : toNull(value);
 }
 
-var Textbox = (function (_Component) {
-  _inherits(Textbox, _Component);
+var Factory = (function (_Component) {
+  _inherits(Factory, _Component);
+
+  function Factory() {
+    _classCallCheck(this, _Factory);
+
+    _Component.apply(this, arguments);
+  }
+
+  Factory.prototype.getTransformer = function getTransformer() {
+    var options = this.props.options;
+    return options.transformer ? options.transformer : this.typeInfo.innerType === _tcombValidation2['default'].Num ? Factory.numberTransformer : Factory.transformer;
+  };
+
+  Factory.prototype.getLocals = function getLocals() {
+    var locals = _Component.prototype.getLocals.call(this);
+    locals.attrs = this.getAttrs();
+    locals.type = this.props.options.type || 'text';
+    return locals;
+  };
+
+  Factory.prototype.getTemplate = function getTemplate() {
+    throw new Error('The Factory getTemplate() method should be overridden.');
+  };
+
+  _createClass(Factory, null, [{
+    key: 'transformer',
+    value: {
+      format: function format(value) {
+        return Nil.is(value) ? null : value;
+      },
+      parse: toNull
+    },
+    enumerable: true
+  }, {
+    key: 'numberTransformer',
+    value: {
+      format: function format(value) {
+        return Nil.is(value) ? null : String(value);
+      },
+      parse: parseNumber
+    },
+    enumerable: true
+  }]);
+
+  var _Factory = Factory;
+  Factory = decorators.attrs(Factory) || Factory;
+  return Factory;
+})(Component);
+
+exports.Factory = Factory;
+
+var Textbox = (function (_Component2) {
+  _inherits(Textbox, _Component2);
 
   function Textbox() {
     _classCallCheck(this, _Textbox);
 
-    _Component.apply(this, arguments);
+    _Component2.apply(this, arguments);
   }
 
   Textbox.prototype.getTransformer = function getTransformer() {
@@ -318,7 +370,7 @@ var Textbox = (function (_Component) {
   };
 
   Textbox.prototype.getLocals = function getLocals() {
-    var locals = _Component.prototype.getLocals.call(this);
+    var locals = _Component2.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.attrs.placeholder = this.getPlaceholder();
     locals.type = this.props.options.type || 'text';
@@ -353,17 +405,17 @@ var Textbox = (function (_Component) {
 
 exports.Textbox = Textbox;
 
-var Checkbox = (function (_Component2) {
-  _inherits(Checkbox, _Component2);
+var Checkbox = (function (_Component3) {
+  _inherits(Checkbox, _Component3);
 
   function Checkbox() {
     _classCallCheck(this, _Checkbox);
 
-    _Component2.apply(this, arguments);
+    _Component3.apply(this, arguments);
   }
 
   Checkbox.prototype.getLocals = function getLocals() {
-    var locals = _Component2.prototype.getLocals.call(this);
+    var locals = _Component3.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     // checkboxes must always have a label
     locals.label = locals.label || this.getDefaultLabel();
@@ -391,13 +443,13 @@ var Checkbox = (function (_Component2) {
 
 exports.Checkbox = Checkbox;
 
-var Select = (function (_Component3) {
-  _inherits(Select, _Component3);
+var Select = (function (_Component4) {
+  _inherits(Select, _Component4);
 
   function Select() {
     _classCallCheck(this, _Select);
 
-    _Component3.apply(this, arguments);
+    _Component4.apply(this, arguments);
   }
 
   Select.prototype.getTransformer = function getTransformer() {
@@ -437,7 +489,7 @@ var Select = (function (_Component3) {
   };
 
   Select.prototype.getLocals = function getLocals() {
-    var locals = _Component3.prototype.getLocals.call(this);
+    var locals = _Component4.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     locals.isMultiple = this.isMultiple();
@@ -478,13 +530,13 @@ var Select = (function (_Component3) {
 
 exports.Select = Select;
 
-var Radio = (function (_Component4) {
-  _inherits(Radio, _Component4);
+var Radio = (function (_Component5) {
+  _inherits(Radio, _Component5);
 
   function Radio() {
     _classCallCheck(this, _Radio);
 
-    _Component4.apply(this, arguments);
+    _Component5.apply(this, arguments);
   }
 
   Radio.prototype.getOptions = function getOptions() {
@@ -497,7 +549,7 @@ var Radio = (function (_Component4) {
   };
 
   Radio.prototype.getLocals = function getLocals() {
-    var locals = _Component4.prototype.getLocals.call(this);
+    var locals = _Component5.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     return locals;
@@ -524,13 +576,13 @@ var Radio = (function (_Component4) {
 
 exports.Radio = Radio;
 
-var Datetime = (function (_Component5) {
-  _inherits(Datetime, _Component5);
+var Datetime = (function (_Component6) {
+  _inherits(Datetime, _Component6);
 
   function Datetime() {
     _classCallCheck(this, _Datetime);
 
-    _Component5.apply(this, arguments);
+    _Component6.apply(this, arguments);
   }
 
   Datetime.prototype.getOrder = function getOrder() {
@@ -538,7 +590,7 @@ var Datetime = (function (_Component5) {
   };
 
   Datetime.prototype.getLocals = function getLocals() {
-    var locals = _Component5.prototype.getLocals.call(this);
+    var locals = _Component6.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.order = this.getOrder();
     return locals;
@@ -566,13 +618,13 @@ var Datetime = (function (_Component5) {
 
 exports.Datetime = Datetime;
 
-var Struct = (function (_Component6) {
-  _inherits(Struct, _Component6);
+var Struct = (function (_Component7) {
+  _inherits(Struct, _Component7);
 
   function Struct() {
     _classCallCheck(this, _Struct);
 
-    _Component6.apply(this, arguments);
+    _Component7.apply(this, arguments);
   }
 
   Struct.prototype.isValueNully = function isValueNully() {
@@ -690,7 +742,7 @@ var Struct = (function (_Component6) {
 
   Struct.prototype.getLocals = function getLocals() {
     var options = this.props.options;
-    var locals = _Component6.prototype.getLocals.call(this);
+    var locals = _Component7.prototype.getLocals.call(this);
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
     locals.className = options.className;
@@ -728,8 +780,8 @@ function toSameLength(value, keys, uidGenerator) {
   return ret;
 }
 
-var List = (function (_Component7) {
-  _inherits(List, _Component7);
+var List = (function (_Component8) {
+  _inherits(List, _Component8);
 
   _createClass(List, null, [{
     key: 'transformer',
@@ -747,7 +799,7 @@ var List = (function (_Component7) {
   function List(props) {
     _classCallCheck(this, _List);
 
-    _Component7.call(this, props);
+    _Component8.call(this, props);
     this.state.keys = this.state.value.map(function () {
       return props.ctx.uidGenerator.next();
     });
@@ -906,7 +958,7 @@ var List = (function (_Component7) {
   List.prototype.getLocals = function getLocals() {
     var options = this.props.options;
     var i18n = this.getI18n();
-    var locals = _Component7.prototype.getLocals.call(this);
+    var locals = _Component8.prototype.getLocals.call(this);
     locals.add = options.disableAdd ? null : {
       label: i18n.add,
       click: this.addItem.bind(this)

--- a/lib/components.js
+++ b/lib/components.js
@@ -134,7 +134,7 @@ var Component = (function (_React$Component) {
   }]);
 
   function Component(props) {
-    _classCallCheck(this, _Component);
+    _classCallCheck(this, Component);
 
     _React$Component.call(this, props);
     this.typeInfo = _util.getTypeInfo(props.type);
@@ -257,7 +257,6 @@ var Component = (function (_React$Component) {
   Component.prototype.getLocals = function getLocals() {
     var options = this.props.options;
     var value = this.state.value;
-    var attrs = this.getAttrs();
     return {
       typeInfo: this.typeInfo,
       path: this.props.ctx.path,
@@ -266,7 +265,7 @@ var Component = (function (_React$Component) {
       label: this.getLabel(),
       onChange: this.onChange.bind(this),
       config: this.getConfig(),
-      value: value, attrs: attrs,
+      value: value,
       disabled: options.disabled,
       help: options.help
     };
@@ -280,8 +279,6 @@ var Component = (function (_React$Component) {
     return _uvdomReact.compile(template(locals));
   };
 
-  var _Component = Component;
-  Component = decorators.attrs(Component) || Component;
   return Component;
 })(_react2['default'].Component);
 
@@ -297,13 +294,13 @@ function parseNumber(value) {
   return isNumeric ? n : toNull(value);
 }
 
-var Textbox = (function (_Component2) {
-  _inherits(Textbox, _Component2);
+var Textbox = (function (_Component) {
+  _inherits(Textbox, _Component);
 
   function Textbox() {
     _classCallCheck(this, _Textbox);
 
-    _Component2.apply(this, arguments);
+    _Component.apply(this, arguments);
   }
 
   Textbox.prototype.getTransformer = function getTransformer() {
@@ -321,7 +318,7 @@ var Textbox = (function (_Component2) {
   };
 
   Textbox.prototype.getLocals = function getLocals() {
-    var locals = _Component2.prototype.getLocals.call(this);
+    var locals = _Component.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.attrs.placeholder = this.getPlaceholder();
     locals.type = this.props.options.type || 'text';
@@ -356,17 +353,17 @@ var Textbox = (function (_Component2) {
 
 exports.Textbox = Textbox;
 
-var Checkbox = (function (_Component3) {
-  _inherits(Checkbox, _Component3);
+var Checkbox = (function (_Component2) {
+  _inherits(Checkbox, _Component2);
 
   function Checkbox() {
     _classCallCheck(this, _Checkbox);
 
-    _Component3.apply(this, arguments);
+    _Component2.apply(this, arguments);
   }
 
   Checkbox.prototype.getLocals = function getLocals() {
-    var locals = _Component3.prototype.getLocals.call(this);
+    var locals = _Component2.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     // checkboxes must always have a label
     locals.label = locals.label || this.getDefaultLabel();
@@ -394,13 +391,13 @@ var Checkbox = (function (_Component3) {
 
 exports.Checkbox = Checkbox;
 
-var Select = (function (_Component4) {
-  _inherits(Select, _Component4);
+var Select = (function (_Component3) {
+  _inherits(Select, _Component3);
 
   function Select() {
     _classCallCheck(this, _Select);
 
-    _Component4.apply(this, arguments);
+    _Component3.apply(this, arguments);
   }
 
   Select.prototype.getTransformer = function getTransformer() {
@@ -440,7 +437,7 @@ var Select = (function (_Component4) {
   };
 
   Select.prototype.getLocals = function getLocals() {
-    var locals = _Component4.prototype.getLocals.call(this);
+    var locals = _Component3.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     locals.isMultiple = this.isMultiple();
@@ -481,13 +478,13 @@ var Select = (function (_Component4) {
 
 exports.Select = Select;
 
-var Radio = (function (_Component5) {
-  _inherits(Radio, _Component5);
+var Radio = (function (_Component4) {
+  _inherits(Radio, _Component4);
 
   function Radio() {
     _classCallCheck(this, _Radio);
 
-    _Component5.apply(this, arguments);
+    _Component4.apply(this, arguments);
   }
 
   Radio.prototype.getOptions = function getOptions() {
@@ -500,7 +497,7 @@ var Radio = (function (_Component5) {
   };
 
   Radio.prototype.getLocals = function getLocals() {
-    var locals = _Component5.prototype.getLocals.call(this);
+    var locals = _Component4.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.options = this.getOptions();
     return locals;
@@ -527,13 +524,13 @@ var Radio = (function (_Component5) {
 
 exports.Radio = Radio;
 
-var Datetime = (function (_Component6) {
-  _inherits(Datetime, _Component6);
+var Datetime = (function (_Component5) {
+  _inherits(Datetime, _Component5);
 
   function Datetime() {
     _classCallCheck(this, _Datetime);
 
-    _Component6.apply(this, arguments);
+    _Component5.apply(this, arguments);
   }
 
   Datetime.prototype.getOrder = function getOrder() {
@@ -541,7 +538,7 @@ var Datetime = (function (_Component6) {
   };
 
   Datetime.prototype.getLocals = function getLocals() {
-    var locals = _Component6.prototype.getLocals.call(this);
+    var locals = _Component5.prototype.getLocals.call(this);
     locals.attrs = this.getAttrs();
     locals.order = this.getOrder();
     return locals;
@@ -569,13 +566,13 @@ var Datetime = (function (_Component6) {
 
 exports.Datetime = Datetime;
 
-var Struct = (function (_Component7) {
-  _inherits(Struct, _Component7);
+var Struct = (function (_Component6) {
+  _inherits(Struct, _Component6);
 
   function Struct() {
     _classCallCheck(this, _Struct);
 
-    _Component7.apply(this, arguments);
+    _Component6.apply(this, arguments);
   }
 
   Struct.prototype.isValueNully = function isValueNully() {
@@ -693,7 +690,7 @@ var Struct = (function (_Component7) {
 
   Struct.prototype.getLocals = function getLocals() {
     var options = this.props.options;
-    var locals = _Component7.prototype.getLocals.call(this);
+    var locals = _Component6.prototype.getLocals.call(this);
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
     locals.className = options.className;
@@ -731,8 +728,8 @@ function toSameLength(value, keys, uidGenerator) {
   return ret;
 }
 
-var List = (function (_Component8) {
-  _inherits(List, _Component8);
+var List = (function (_Component7) {
+  _inherits(List, _Component7);
 
   _createClass(List, null, [{
     key: 'transformer',
@@ -750,7 +747,7 @@ var List = (function (_Component8) {
   function List(props) {
     _classCallCheck(this, _List);
 
-    _Component8.call(this, props);
+    _Component7.call(this, props);
     this.state.keys = this.state.value.map(function () {
       return props.ctx.uidGenerator.next();
     });
@@ -909,7 +906,7 @@ var List = (function (_Component8) {
   List.prototype.getLocals = function getLocals() {
     var options = this.props.options;
     var i18n = this.getI18n();
-    var locals = _Component8.prototype.getLocals.call(this);
+    var locals = _Component7.prototype.getLocals.call(this);
     locals.add = options.disableAdd ? null : {
       label: i18n.add,
       click: this.addItem.bind(this)

--- a/src/components.js
+++ b/src/components.js
@@ -259,6 +259,40 @@ function parseNumber(value) {
   return isNumeric ? n : toNull(value);
 }
 
+
+@decorators.attrs
+export class Factory extends Component {
+
+  static transformer = {
+    format: value => Nil.is(value) ? null : value,
+    parse: toNull
+  };
+
+  static numberTransformer = {
+    format: value => Nil.is(value) ? null : String(value),
+    parse: parseNumber
+  };
+
+  getTransformer() {
+    const options = this.props.options;
+    return options.transformer ? options.transformer :
+        this.typeInfo.innerType === t.Num ? Factory.numberTransformer :
+            Factory.transformer;
+  }
+
+
+  getLocals() {
+    const locals = super.getLocals();
+    locals.attrs = this.getAttrs();
+    locals.type = this.props.options.type || 'text';
+    return locals;
+  }
+
+  getTemplate() {
+    throw new Error('The Factory getTemplate() method should be overridden.');
+  }
+}
+
 @decorators.attrs
 @decorators.template('textbox')
 export class Textbox extends Component {

--- a/src/components.js
+++ b/src/components.js
@@ -93,7 +93,6 @@ export const decorators = {
 
 };
 
-@decorators.attrs
 export class Component extends React.Component {
 
   static transformer = {
@@ -226,7 +225,6 @@ export class Component extends React.Component {
   getLocals() {
     const options = this.props.options;
     const value = this.state.value;
-    const attrs = this.getAttrs();
     return {
       typeInfo: this.typeInfo,
       path: this.props.ctx.path,
@@ -235,7 +233,7 @@ export class Component extends React.Component {
       label: this.getLabel(),
       onChange: this.onChange.bind(this),
       config: this.getConfig(),
-      value, attrs,
+      value,
       disabled: options.disabled,
       help: options.help
     };

--- a/src/components.js
+++ b/src/components.js
@@ -93,6 +93,7 @@ export const decorators = {
 
 };
 
+@decorators.attrs
 export class Component extends React.Component {
 
   static transformer = {
@@ -225,6 +226,7 @@ export class Component extends React.Component {
   getLocals() {
     const options = this.props.options;
     const value = this.state.value;
+    const attrs = this.getAttrs();
     return {
       typeInfo: this.typeInfo,
       path: this.props.ctx.path,
@@ -233,7 +235,7 @@ export class Component extends React.Component {
       label: this.getLabel(),
       onChange: this.onChange.bind(this),
       config: this.getConfig(),
-      value,
+      value, attrs,
       disabled: options.disabled,
       help: options.help
     };


### PR DESCRIPTION
This pull request adds a generic 'Factory' which can be extended to more easily create a custom Factory.  This means you no longer have to extend 'Textbox' (when it isn't a textbox) nor do you have to extend Component (which requires more work for validation, state, etc)  An example of a generic Component factory might look like this:

```javascript

export default (Component) => {
    class ComponentFactory extends t.form.Factory {
        constructor(props) {
            super(props);
            this.onChange = this.onChange.bind(this);
            this.state = {value: this.props.value};
        }




        onChange(e) {
            this.state.value = e.target.value;
            this.props.onChange(this.state.value, this.props.ctx.path);
        }


        getTemplate() {
            return (locals) => {
                return (
                    <Component
                        {...getErrorAttributes(locals)}
                        {...this.props.options}
                        onChange={this.onChange}
                        value={this.props.value}
                        />);
            };
        }
    }

    ComponentFactory.displayName = 'TcombComponentWrapper';
    ComponentFactory.propTypes = {
        ctx: React.PropTypes.object,
        onChange: React.PropTypes.func,
        options: React.PropTypes.object,
        path: React.PropTypes.array,
        type: React.PropTypes.func,
        value: React.PropTypes.node
    };
    return ComponentFactory;
}

```