### PR TITLE
use keys returned from getTypeProps as refs

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -485,7 +485,8 @@ export class Struct extends Component {
 
   getValue() {
     const value = {}
-    for (const ref in this.refs) {
+    const props = this.getTypeProps()
+    for (const ref in props) {
       if (this.refs.hasOwnProperty(ref)) {
         value[ref] = this.refs[ref].getValue()
       }
@@ -504,7 +505,8 @@ export class Struct extends Component {
       return new t.ValidationResult({errors: [], value: null})
     }
 
-    for (const ref in this.refs) {
+    const props = this.getTypeProps()
+    for (const ref in props) {
       if (this.refs.hasOwnProperty(ref)) {
         result = this.refs[ref].validate()
         errors = errors.concat(result.errors)


### PR DESCRIPTION
This might be heresy, but in one case I have nested refs inside of custom templates. When validating structs it iterates over all refs and will fail to call `validate` on my own refs (which are not tcomb generated components). I am open to other ways of achieving this.