### PR TITLE
use empty string instead of null in textbox format

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -288,12 +288,12 @@ function parseNumber(value) {
 export class Textbox extends Component {
 
   static transformer = {
-    format: value => Nil.is(value) ? null : value,
+    format: value => Nil.is(value) ? '' : value,
     parse: toNull
   }
 
   static numberTransformer = {
-    format: value => Nil.is(value) ? null : String(value),
+    format: value => Nil.is(value) ? '' : String(value),
     parse: parseNumber
   }
 

--- a/test/components/Textbox.js
+++ b/test/components/Textbox.js
@@ -237,8 +237,8 @@ tape('Textbox', ({ test }) => {
         options: {},
         ctx: ctx
       }).getLocals().value,
-      null,
-      'default value should be null')
+      '',
+      'default value should be \'\'')
 
     assert.strictEqual(
       new Textbox({


### PR DESCRIPTION
https://github.com/facebook/react/issues/2533

https://facebook.github.io/react/blog/#new-deprecations-introduced-with-a-warning

![image](https://cloud.githubusercontent.com/assets/1269858/14373557/eb8b120a-fd7d-11e5-86ed-e0495347d6ee.png)
