### PR TITLE
add support for matching union options

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -555,7 +555,7 @@ export class Struct extends Component {
         const propValue = value[prop]
         const propType = getTypeFromUnion(props[prop], propValue)
         const fieldsOptions = options.fields || noobj
-        const propOptions = getOptions(fieldsOptions[prop], noobj, propValue)
+        const propOptions = getOptions(fieldsOptions[prop], noobj, propValue, props[prop])
         inputs[prop] = React.createElement(getFormComponent(propType, propOptions), {
           key: prop,
           ref: prop,
@@ -735,7 +735,7 @@ export class List extends Component {
     const value = this.state.value
     return value.map((itemValue, i) => {
       const itemType = getTypeFromUnion(this.typeInfo.innerType.meta.type, itemValue)
-      const itemOptions = getOptions(options.item, noobj, itemValue)
+      const itemOptions = getOptions(options.item, noobj, itemValue, this.typeInfo.innerType.meta.type)
       const ItemComponent = getFormComponent(itemType, itemOptions)
       const buttons = []
       if (!options.disableRemove) {
@@ -835,7 +835,7 @@ export class Form extends React.Component {
 
     const value = this.props.value
     const type = getTypeFromUnion(this.props.type, value)
-    const options = getOptions(this.props.options, noobj, value)
+    const options = getOptions(this.props.options, noobj, value, this.props.type)
 
     // this is in the render method because I need this._reactInternalInstance._rootNodeID in React ^0.14.0
     // and this._reactInternalInstance._nativeContainerInfo._idCounter in React ^15.0.0

--- a/src/util.js
+++ b/src/util.js
@@ -123,12 +123,22 @@ export function getTypeFromUnion(type, value) {
   return type
 }
 
-export function getOptions(options, defaultOptions, value) {
+export function getOptions(options, defaultOptions, value, type) {
   if (t.Nil.is(options)) {
     return defaultOptions
   }
   if (t.Function.is(options)) {
     return options(value)
+  }
+  if (containsUnion(type)) {
+    const concreteTypeName = getUnionConcreteType(type, value).meta.name
+    let concreteOptions = options
+    if (options.case) {
+      const concreteTypeOptions = options.case[concreteTypeName] || {}
+      concreteOptions = merge(options, concreteTypeOptions)
+      delete concreteOptions.case
+    }
+    return concreteOptions
   }
   return options
 }


### PR DESCRIPTION
This adds support to define options which would vary among concrete types in union.
For example:
```js
const options = {
  item: {
    case: {
      KnownAccount: { template: knownAccountTemplate },
      UnknownAccount: { template: unknownAccountTemplate }
    }
  }
}
```

This is basically shorthand to write custom:
```js
const options = {
  item: (value) => {
    const concreteAccountType = Account.dispatch(value);
    switch (concreteAccountType.meta.name) {
      case 'KnownAccount': {
        return { template: knownAccountTemplate }
      }
      case 'UnknownAccount': {
        return { template: knownAccountTemplate }
      }
    }
  }
}
```

If you approve this, I could write tests and additional documentation.

Please note, that this causes some unneeded renders of some of item (or props in case of Struct) components, because it will create new instance of item options object even if value didn't change. But this is the case as when options function is used (e.g. in my second example), so I think this PR does not add to this issue. Maybe some kind of memoization technique could solve both problems.