### PR TITLE
retain static functions when constructing concrete type from union

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -114,9 +114,15 @@ function getUnionConcreteType(type, value) {
     }
     return concreteType
   } else if (kind === 'maybe') {
-    return t.maybe(getUnionConcreteType(type.meta.type, value), type.meta.name)
+    const maybeConcrete = t.maybe(getUnionConcreteType(type.meta.type, value), type.meta.name)
+    maybeConcrete.getValidationErrorMessage = type.getValidationErrorMessage
+    maybeConcrete.getTcombFormFactory = type.getTcombFormFactory
+    return maybeConcrete
   } else if (kind === 'subtype') {
-    return t.subtype(getUnionConcreteType(type.meta.type, value), type.meta.predicate, type.meta.name)
+    const subtypeConcrete = t.subtype(getUnionConcreteType(type.meta.type, value), type.meta.predicate, type.meta.name)
+    subtypeConcrete.getValidationErrorMessage = type.getValidationErrorMessage
+    subtypeConcrete.getTcombFormFactory = type.getTcombFormFactory
+    return subtypeConcrete
   }
 }
 


### PR DESCRIPTION
Refinement and Maybe types over unions should not "loose" getValidationErrorMessage and getTcombFormFactory static functions when processed by factories.

Example:
```js
    const AccountType = t.enums.of([
      'type 1',
      'type 2',
      'other'
    ], 'AccountType')

    const KnownAccount = t.struct({
      type: AccountType,
      balance: t.Number,
    }, 'KnownAccount')

    const UnknownAccount = KnownAccount.extend({
      label: t.String,
    }, 'UnknownAccount')

    const Account = t.union([KnownAccount, UnknownAccount], 'Account')

    const RestrictedAccount = t.refinement(Account, x => x.balance <= 1000 )
    RestrictedAccount.getValidationErrorMessage = 'This message gets lost when factories construct new refinement over concrete type'
```