### PR TITLE
allow hasError to be a function

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -208,6 +208,11 @@ export class Component extends React.Component {
   }
 
   hasError() {
+    var optionsHasError = this.props.options.hasError
+    if (t.Function.is(optionsHasError)) {
+      const {path, context} = this.getValidationOptions()
+      return optionsHasError(this.getValue(), path, context)
+    }
     return this.props.options.hasError || this.state.hasError
   }
 


### PR DESCRIPTION
This PR introduce the ability to use a function in hasError, similar to getValidationErrorMessage, which allow error message to be feed in by function, very useful for server side return results + state based error message lookup.
