### PR TITLE
Removed refs management fix

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -462,11 +462,17 @@ export class Datetime extends Component {
 }
 
 class ComponentWithChildRefs extends Component {
+
   childRefs = {};
 
   setChildRefFor = prop => ref => {
-    this.childRefs[prop] = ref
+    if (ref) {
+      this.childRefs[prop] = ref
+    } else {
+      delete this.childRefs[prop]
+    }
   }
+
 }
 
 @decorators.templates

--- a/test/components/Struct.js
+++ b/test/components/Struct.js
@@ -1,6 +1,8 @@
 import tape from 'tape'
-import t from 'tcomb-validation'
-import { Struct } from '../../src/components'
+import React from 'react'
+import ReactTestRenderer from 'react-test-renderer'
+import t from '../../src/main'
+import { Struct, Form } from '../../src/components'
 import { ctx } from './util'
 
 tape('Struct', ({ test }) => {
@@ -35,5 +37,50 @@ tape('Struct', ({ test }) => {
     })
 
     assert.strictEqual(component.getInputs().name.props.options.disabled, true)
+  })
+
+  test('manages refs correctly', (assert) => {
+    assert.plan(4)
+
+    const modelA = t.struct({
+      name: t.String
+    })
+    const modelB = modelA.extend({
+      age: t.Number
+    })
+
+    let formRef = null
+    const setRef = ref => {
+      formRef = ref
+    }
+
+    const formProps = {
+      key: 'form',
+      ref: setRef,
+      value: {
+        name: 'test',
+        age: 5
+      }
+    }
+
+    const formB = React.createElement(Form, {
+      ...formProps,
+      type: modelB,
+    })
+
+    const renderer = ReactTestRenderer.create(formB)
+
+    assert.strictEqual(Object.keys(formRef.inputRef.childRefs).length, 2, 'should have 2 ref keys')
+    assert.strictEqual(formRef.validate().errors.length, 0, 'validation works')
+
+    const formA = React.createElement(Form, {
+      ...formProps,
+      type: modelA,
+    })
+
+    renderer.update(formA)
+
+    assert.strictEqual(Object.keys(formRef.inputRef.childRefs).length, 1, 'should have 1 ref keys')
+    assert.strictEqual(formRef.validate().errors.length, 0, 'validation works')
   })
 })


### PR DESCRIPTION
#406 introduced issue with refs management 😢 
when form model changes and some refs should be removed, it set value `null` to corresponding refs keys. Original react string refs removes ref key completely from registry in such cases.

It causes issues in some edge cases, like validation of such updated form (because struct uses `hasOwnProperty` to determine is ref available).

This PR restores original string refs behaviour with new callback refs.
